### PR TITLE
feat: add Live Preview support for GitHub star counts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,6 @@
 import { App, MarkdownView, Notice, Plugin, PluginSettingTab, Setting, MarkdownPostProcessorContext, requestUrl } from 'obsidian';
+import { EditorView, ViewPlugin, ViewUpdate, Decoration, DecorationSet, WidgetType } from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
 
 
 interface GitHubStarsSettings {
@@ -19,6 +21,120 @@ const DEFAULT_SETTINGS: GitHubStarsSettings = {
 interface CacheEntry {
 	stars: number;
 	timestamp: number;
+}
+
+/**
+ * Build the CodeMirror 6 ViewPlugin for Live Preview star count display.
+ * The plugin and widget classes are defined inside this function so they
+ * can capture a reference to the main Obsidian plugin instance.
+ */
+function buildGitHubStarsViewPlugin(plugin: GitHubStarsPlugin) {
+	class StarsWidget extends WidgetType {
+		constructor(private owner: string, private repo: string) {
+			super();
+		}
+
+		eq(other: StarsWidget): boolean {
+			return this.owner === other.owner && this.repo === other.repo;
+		}
+
+		toDOM(): HTMLElement {
+			const span = document.createElement('span');
+			span.addClass('github-stars-count');
+
+			// Use cached value for instant rendering when available
+			const cacheKey = `${this.owner}/${this.repo}`;
+			const cachedEntry = plugin.cache[cacheKey];
+			const now = Date.now();
+			const expiryTime = plugin.settings.cacheExpiry * 60 * 1000;
+
+			if (cachedEntry && (now - cachedEntry.timestamp < expiryTime)) {
+				span.setText(plugin.formatStarCount(cachedEntry.stars));
+				return span;
+			}
+
+			// Show loading state and fetch asynchronously
+			span.addClass('github-stars-loading');
+			span.setText('⭐ ...');
+
+			plugin.getStarCount(this.owner, this.repo).then(stars => {
+				span.removeClass('github-stars-loading');
+				if (stars !== null) {
+					span.setText(plugin.formatStarCount(stars));
+				} else {
+					span.setText('⭐ ?');
+					span.addClass('github-stars-error');
+				}
+			}).catch(() => {
+				span.removeClass('github-stars-loading');
+				span.setText('⭐ ?');
+				span.addClass('github-stars-error');
+			});
+
+			return span;
+		}
+	}
+
+	class StarsViewPlugin {
+		decorations: DecorationSet;
+
+		constructor(view: EditorView) {
+			this.decorations = this.buildDecorations(view);
+		}
+
+		update(update: ViewUpdate) {
+			if (update.docChanged || update.viewportChanged) {
+				this.decorations = this.buildDecorations(update.view);
+			}
+		}
+
+		destroy() {}
+
+		buildDecorations(view: EditorView): DecorationSet {
+			const builder = new RangeSetBuilder<Decoration>();
+			const githubUrlRegex = /https?:\/\/(www\.)?github\.com\/([^/\s)#?]+)\/([^/\s)#?]+)(\/[^\s)]*)?\/?(#[^\s)]*)?/g;
+
+			for (const { from, to } of view.visibleRanges) {
+				const text = view.state.doc.sliceString(from, to);
+				let match;
+
+				while ((match = githubUrlRegex.exec(text)) !== null) {
+					const owner = match[2];
+					let repo = match[3];
+
+					if (repo.endsWith('.git')) {
+						repo = repo.slice(0, -4);
+					}
+
+					const matchEnd = from + match.index + match[0].length;
+					let insertPos = matchEnd;
+
+					// If inside a markdown link [text](url), place widget after the closing )
+					if (matchEnd < view.state.doc.length) {
+						const charAfter = view.state.doc.sliceString(matchEnd, matchEnd + 1);
+						if (charAfter === ')') {
+							insertPos = matchEnd + 1;
+						}
+					}
+
+					builder.add(
+						insertPos,
+						insertPos,
+						Decoration.widget({
+							widget: new StarsWidget(owner, repo),
+							side: 1,
+						})
+					);
+				}
+			}
+
+			return builder.finish();
+		}
+	}
+
+	return ViewPlugin.fromClass(StarsViewPlugin, {
+		decorations: (value: StarsViewPlugin) => value.decorations,
+	});
 }
 
 export default class GitHubStarsPlugin extends Plugin {
@@ -60,8 +176,11 @@ export default class GitHubStarsPlugin extends Plugin {
 			console.error('Error loading cache:', error);
 		}
 
-		// Register the markdown post processor to find and enhance GitHub links
+		// Register the markdown post processor to find and enhance GitHub links (Reading View)
 		this.registerMarkdownPostProcessor(this.processMarkdown.bind(this));
+
+		// Register the CodeMirror 6 editor extension for Live Preview support
+		this.registerEditorExtension(buildGitHubStarsViewPlugin(this));
 
 		// Add settings tab
 		this.addSettingTab(new GitHubStarsSettingTab(this.app, this));


### PR DESCRIPTION
## Summary

Add Live Preview (Editing View) support for displaying GitHub star counts using CodeMirror 6 editor extensions.

Previously, star counts only displayed in Reading View via the `MarkdownPostProcessor`. This PR adds a CM6 `ViewPlugin` with `WidgetType` decorations so star counts also appear inline in Live Preview mode.

## Changes

- **`StarsWidget`** (`WidgetType`): Renders the star count badge. Uses the plugin's cache for instant display when data is available; otherwise shows a loading indicator and fetches asynchronously via the GitHub API.
- **`StarsViewPlugin`** (`ViewPlugin`): Scans the editor's visible ranges for GitHub repository URLs using regex. Places widget decorations after each matched link.
- Widget placement correctly handles markdown link syntax `[text](url)` by positioning after the closing `)`, so the badge appears after the rendered link in Live Preview.
- Registered via `registerEditorExtension()` in `onload()`.

## How it works

The `buildGitHubStarsViewPlugin()` function wraps the CM6 classes so they can capture a reference to the main plugin instance (needed for cache access, settings, and API calls). The `@codemirror/view` and `@codemirror/state` packages are marked as external in esbuild so Obsidian provides the correct CM6 versions at runtime.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
